### PR TITLE
A static method with dynamic argument cannot be mocked if the class is in a different assembly than the unit test

### DIFF
--- a/Telerik.JustMock.DemoLib/Objects/ClassWithDynamicDataMethod.cs
+++ b/Telerik.JustMock.DemoLib/Objects/ClassWithDynamicDataMethod.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2018 Telerik EAD
+ Copyright © 2018 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,21 +15,20 @@
    limitations under the License.
 */
 
-
 using System;
 
 namespace Telerik.JustMock.DemoLib.Objects
 {
 	public class ClassWithDynamicDataMethod
-    {
-        public bool Method1()
-        {
-            return Method2(new { V1 = "A" });
-        }
+	{
+		public bool Method1()
+		{
+			return Method2(new { V1 = "A" });
+		}
 
-        public static bool Method2(dynamic data)
-        {
-            throw new NotImplementedException();
-        }
+		public static bool Method2(dynamic data)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/Telerik.JustMock.DemoLib/Objects/ClassWithDynamicDataMethod.cs
+++ b/Telerik.JustMock.DemoLib/Objects/ClassWithDynamicDataMethod.cs
@@ -1,0 +1,35 @@
+/*
+ JustMock Lite
+ Copyright © 2010-2018 Telerik EAD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+using System;
+
+namespace Telerik.JustMock.DemoLib.Objects
+{
+	public class ClassWithDynamicDataMethod
+    {
+        public bool Method1()
+        {
+            return Method2(new { V1 = "A" });
+        }
+
+        public static bool Method2(dynamic data)
+        {
+            throw new NotImplementedException();
+        }
+	}
+}

--- a/Telerik.JustMock.DemoLib/Telerik.JustMock.DemoLib.csproj
+++ b/Telerik.JustMock.DemoLib/Telerik.JustMock.DemoLib.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telerik.JustMock.DemoLib</RootNamespace>
     <AssemblyName>Telerik.JustMock.DemoLib</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -35,6 +35,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -107,6 +108,7 @@
     <Compile Include="Objects\Configuration.cs" />
     <Compile Include="ConfigurationService.cs" />
     <Compile Include="Objects\ILogger.cs" />
+    <Compile Include="Objects\ClassWithDynamicDataMethod.cs" />
     <Compile Include="Objects\InternalObject.cs" />
     <Compile Include="Objects\Logger.cs" />
     <Compile Include="OpenAccess\OpenAccessContext.cs" />

--- a/Telerik.JustMock.DemoLibSigned/Telerik.JustMock.DemoLibSigned.csproj
+++ b/Telerik.JustMock.DemoLibSigned/Telerik.JustMock.DemoLibSigned.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telerik.JustMock.DemoLibSigned</RootNamespace>
     <AssemblyName>Telerik.JustMock.DemoLibSigned</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>

--- a/Telerik.JustMock/Core/MatcherTree/ValueMatcher.cs
+++ b/Telerik.JustMock/Core/MatcherTree/ValueMatcher.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Telerik.JustMock.Core.Expressions;
 
 namespace Telerik.JustMock.Core.MatcherTree
@@ -82,12 +83,45 @@ namespace Telerik.JustMock.Core.MatcherTree
 						.MakeGenericMethod(elementType);
 					return (bool) sequenceEqualsMethod.Invoke(null, new object[] { this.Value, valueMatcher.Value });
 				}
+                else if (IsAnonymousType(thisType) && IsAnonymousType(otherType))
+                {
+                    var thisTypeProperties = thisType.GetProperties();
+                    var otherTypeProperties = otherType.GetProperties();
+                    if (thisTypeProperties.Length != otherTypeProperties.Length)
+                    {
+                        return false;
+                    }
+                    for (int i = 0; i < thisTypeProperties.Length; ++i)
+                    {
+                        var thisTypeProperty = thisTypeProperties[i];
+                        var otherTypeProperty = otherTypeProperties[i];
+                        if (!thisTypeProperty.Name.Equals(otherTypeProperty.Name) || !thisTypeProperty.PropertyType.Equals(otherTypeProperty.PropertyType))
+                        {
+                            return false;
+                        }
+                        object thisTypePropertyValue = thisTypeProperty.GetGetMethod().Invoke(this.Value, null);
+                        object otherTypePropertyValue = otherTypeProperty.GetGetMethod().Invoke(valueMatcher.Value, null);
+                        if (!thisTypePropertyValue.Equals(otherTypePropertyValue))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
 			}
 
 			return false;
 		}
 
-		private static bool IsSystemCollection(Type type)
+        public static Boolean IsAnonymousType(Type type)
+        {
+            return type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Count() > 0
+                 && type.FullName.Contains("AnonymousType");
+        }
+
+
+        private static bool IsSystemCollection(Type type)
 		{
 			return type.FullName.StartsWith("System.Collections.") && type.IsClass && !type.IsAbstract
 				 || type.IsArray;


### PR DESCRIPTION
o extend ValueMarcher to handle anonymous types by matching their properties