### PR TITLE
Revert "Fix AssertSet can't verify the occurrence of a property set when a result of a mocked object is used as a value"

### DIFF
--- a/Telerik.JustMock.Tests/AssertionFixture.cs
+++ b/Telerik.JustMock.Tests/AssertionFixture.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015,2018 Telerik EAD
+ Copyright © 2010-2015 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -1064,60 +1064,7 @@ namespace Telerik.JustMock.Tests
 				DebugView.IsTraceEnabled = traceEnabled;
 			}
 		}
-
-        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
-        public void ShouldAssertSetUsingRighsideLamdaMockResultOccursOnce()
-        {
-            // Arrange
-            var fooMock = Mock.Create<IFoo>();
-            var barMock = Mock.Create<Bar>();
-            Mock.Arrange(() => barMock.Echo(Arg.IsAny<int>())).Returns(2);
-
-            // Act
-            fooMock.Value = barMock.Echo(1);
-
-            // Assert
-            Mock.AssertSet(() => fooMock.Value = barMock.Echo(1), Occurs.Once());
-        }
-
-        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
-        public void ShouldAssertSetUsingRighsideLamdaMockResultOccursNever()
-        {
-            // Arrange
-            var fooMock = Mock.Create<IFoo>();
-            var barMock = Mock.Create<Bar>();
-            Mock.Arrange(() => barMock.Echo(Arg.IsAny<int>())).Returns(2);
-
-            // Assert
-            Mock.AssertSet(() => fooMock.Value = barMock.Echo(1), Occurs.Never());
-        }
-
-        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
-        public void ShouldAssertSetUsingRighsideLamdaUnmockedResultOccursOnce()
-        {
-            // Arrange
-            var fooMock = Mock.Create<IFoo>();
-            var bar = new Bar();
-
-            // Act
-            fooMock.Value = bar.Echo(1);
-
-            // Assert
-            Mock.AssertSet(() => fooMock.Value = bar.Echo(1), Occurs.Once());
-        }
-
-        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
-        public void ShouldAssertSetUsingRighsideLamdaUnmockedResultOccursNever()
-        {
-            // Arrange
-            var fooMock = Mock.Create<IFoo>();
-            var bar = new Bar();
-
-            // Assert
-            Mock.AssertSet(() => fooMock.Value = bar.Echo(1), Occurs.Never());
-        }
-    }
-
+	}
 #if !XUNIT
 #if !PORTABLE
 #if !NUNIT

--- a/Telerik.JustMock/Core/Invocation.cs
+++ b/Telerik.JustMock/Core/Invocation.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015,2018 Telerik EAD
+ Copyright © 2010-2015 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ namespace Telerik.JustMock.Core
 		#endregion
 
 		internal bool InArrange { get; set; }
-		internal bool InAssertSet { get; set; }
 		internal bool Recording { get; set; }
 		internal bool RetainBehaviorDuringRecording { get; set; }
 		internal MocksRepository Repository { get; set; }

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015,2108 Telerik EAD
+ Copyright © 2010-2015 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -92,16 +92,16 @@ namespace Telerik.JustMock.Core
 
 		internal static IMockMixin GetMockMixin(object obj, Type objType)
 		{
-			IMockMixin asMixin = GetMockMixinFromAnyMock(obj);
-			if (asMixin != null)
-			{
-				return asMixin;
-			}
+            IMockMixin asMixin = GetMockMixinFromAnyMock(obj);
+            if (asMixin != null)
+            {
+                return asMixin;
+            }
 
-			if (obj != null && objType == null)
-			{
-				objType = obj.GetType();
-			}
+            if (obj != null && objType == null)
+            {
+                objType = obj.GetType();
+            }
 
 			if (obj != null)
 			{
@@ -287,7 +287,7 @@ namespace Telerik.JustMock.Core
 			while (queue.Count > 0)
 			{
 				MatcherNodeAndParent current = queue.Dequeue();
-				IMatcherTreeNode newCurrent = current.Node.Clone();
+                IMatcherTreeNode newCurrent = current.Node.Clone();
 				foreach (IMatcherTreeNode node in current.Node.Children)
 				{
 					queue.Enqueue(new MatcherNodeAndParent(node, newCurrent));
@@ -309,20 +309,20 @@ namespace Telerik.JustMock.Core
 
 			if (parentRepository != null)
 			{
-				foreach (var root in parentRepository.arrangementTreeRoots)
-				{
-					this.arrangementTreeRoots.Add(root.Key, DeepCopy(root.Value));
-				}
+                foreach (var root in parentRepository.arrangementTreeRoots)
+                {
+                    this.arrangementTreeRoots.Add(root.Key, DeepCopy(root.Value));
+                }
 
-				foreach (var root in parentRepository.invocationTreeRoots)
-				{
-					this.invocationTreeRoots.Add(root.Key, DeepCopy(root.Value));
-				}
+                foreach (var root in parentRepository.invocationTreeRoots)
+                {
+                    this.invocationTreeRoots.Add(root.Key, DeepCopy(root.Value));
+                }
 
-				foreach (var kvp in parentRepository.valueStore)
-				{
-					this.valueStore.Add(kvp.Key, kvp.Value);
-				}
+                foreach (var kvp in parentRepository.valueStore)
+                {
+                    this.valueStore.Add(kvp.Key, kvp.Value);
+                }
 
 				foreach (WeakReference mockRef in parentRepository.controlledMocks)
 				{
@@ -354,18 +354,18 @@ namespace Telerik.JustMock.Core
 		{
 			DebugView.TraceEvent(IndentLevel.Configuration, () => String.Format("Resetting mock repository related to {0}.", this.method));
 
-			foreach (var type in this.arrangedTypes)
-			{
-				ProfilerInterceptor.EnableInterception(type, false, this);
-			}
+            foreach (var type in this.arrangedTypes)
+            {
+                ProfilerInterceptor.EnableInterception(type, false, this);
+            }
 
-			this.arrangedTypes.Clear();
+            this.arrangedTypes.Clear();
 			this.staticMixinDatabase.Clear();
 
-			foreach (var method in this.globallyInterceptedMethods)
-			{
-				ProfilerInterceptor.UnregisterGlobalInterceptor(method, this);
-			}
+            foreach (var method in this.globallyInterceptedMethods)
+            {
+                ProfilerInterceptor.UnregisterGlobalInterceptor(method, this);
+            }
 			this.globallyInterceptedMethods.Clear();
 
 			lock (externalMixinDatabase)
@@ -397,7 +397,6 @@ namespace Telerik.JustMock.Core
 			}
 
 			invocation.InArrange = this.sharedContext.InArrange;
-			invocation.InAssertSet = this.sharedContext.InAssertSet;
 			invocation.Recording = this.Recorder != null;
 			invocation.RetainBehaviorDuringRecording = this.sharedContext.DispatchToMethodMocks;
 			invocation.Repository = this;
@@ -416,20 +415,15 @@ namespace Telerik.JustMock.Core
 
 			if (!methodMockProcessed)
 			{
-				// We have to be careful for the potential exception throwing in the assertion context,
-				// so skip CallOriginalBehavior processing
 				var mock = invocation.MockMixin;
 				if (mock != null)
 				{
-					var fallbackBehaviorsToExecute =
-						mock.FallbackBehaviors
-							.Where(behavior => !invocation.InAssertSet || !(behavior is CallOriginalBehavior))
-							.ToList();
-					fallbackBehaviorsToExecute.ForEach(behavior => behavior.Process(invocation));
+					foreach (var behavior in mock.FallbackBehaviors)
+						behavior.Process(invocation);
 				}
 				else
 				{
-					invocation.CallOriginal = CallOriginalBehavior.ShouldCallOriginal(invocation) && !invocation.InAssertSet;
+					invocation.CallOriginal = CallOriginalBehavior.ShouldCallOriginal(invocation);
 				}
 			}
 
@@ -440,14 +434,14 @@ namespace Telerik.JustMock.Core
 		internal T GetValue<T>(object owner, object key, T dflt)
 		{
 			object value;
-			if (valueStore.TryGetValue(new KeyValuePair<object, object>(owner, key), out value))
-			{
-				return (T)value;
-			}
-			else
-			{
-				return dflt;
-			}
+            if (valueStore.TryGetValue(new KeyValuePair<object, object>(owner, key), out value))
+            {
+                return (T)value;
+            }
+            else
+            {
+                return dflt;
+            }
 		}
 
 		internal void StoreValue<T>(object owner, object key, T value)
@@ -462,19 +456,19 @@ namespace Telerik.JustMock.Core
 
 		internal void AddMatcherInContext(IMatcher matcher)
 		{
-			if (!this.sharedContext.InArrange || this.sharedContext.Recorder != null)
-			{
-				this.matchersInContext.Add(matcher);
-			}
+            if (!this.sharedContext.InArrange || this.sharedContext.Recorder != null)
+            {
+                this.matchersInContext.Add(matcher);
+            }
 		}
 
 		internal object Create(Type type, MockCreationSettings settings)
 		{
 			object delegateResult;
-			if (TryCreateDelegate(type, settings, out delegateResult))
-			{
-				return delegateResult;
-			}
+            if (TryCreateDelegate(type, settings, out delegateResult))
+            {
+                return delegateResult;
+            }
 
 			bool isSafeMock = settings.FallbackBehaviors.OfType<CallOriginalBehavior>().Any();
 			this.CheckIfCanMock(type, !isSafeMock);
@@ -516,7 +510,7 @@ namespace Telerik.JustMock.Core
 				}
 			}
 
-			IMockMixin mockMixin = instance as IMockMixin;
+            IMockMixin mockMixin = instance as IMockMixin;
 
 			if (instance == null)
 			{
@@ -814,18 +808,6 @@ namespace Telerik.JustMock.Core
 			}
 		}
 
-		internal void AssertSetAction(string message, Action memberAction, Args args = null, Occurs occurs = null)
-		{
-			using (MockingContext.BeginFailureAggregation(message))
-			{
-				using (this.sharedContext.StartAssertSet())
-				{
-					var callPattern = ConvertActionToCallPattern(memberAction, true);
-					AssertForCallPattern(callPattern, args, occurs);
-				}
-			}
-		}
-
 		internal void AssertMethodInfo(string message, object instance, MethodBase method, object[] arguments, Occurs occurs)
 		{
 			using (MockingContext.BeginFailureAggregation(message))
@@ -1003,7 +985,7 @@ namespace Telerik.JustMock.Core
 			callPattern.AdjustForExtensionMethod();
 		}
 
-		private CallPattern ConvertActionToCallPattern(Action memberAction, bool dispatchToMethodMocks = false)
+		private CallPattern ConvertActionToCallPattern(Action memberAction)
 		{
 			var callPattern = new CallPattern();
 
@@ -1011,7 +993,7 @@ namespace Telerik.JustMock.Core
 
 			var recorder = new DelegatingRecorder();
 			recorder.Record += invocation => lastInvocation = invocation;
-			using (this.StartRecording(recorder, dispatchToMethodMocks))
+			using (this.StartRecording(recorder, false))
 			{
 				memberAction();
 			}
@@ -1603,7 +1585,7 @@ namespace Telerik.JustMock.Core
 			ConvertInvocationToCallPattern(invocation, callPattern);
 
 			MethodInfoMatcherTreeNode funcRoot = null;
-			if (!invocation.InArrange && !invocation.InAssertSet)
+			if (!invocation.InArrange)
 			{
 				if (!invocationTreeRoots.TryGetValue(callPattern.Method, out funcRoot))
 				{
@@ -1614,7 +1596,7 @@ namespace Telerik.JustMock.Core
 
 			var methodMock = DispatchInvocationToArrangements(callPattern, invocation);
 
-			if (!invocation.InArrange && !invocation.InAssertSet)
+			if (!invocation.InArrange)
 			{
 				funcRoot.AddOrUpdateOccurence(callPattern, methodMock);
 			}
@@ -1651,39 +1633,16 @@ namespace Telerik.JustMock.Core
 
 			methodMock.IsUsed = true; //used to correctly determine inSequence arranges
 
-			GetBehaviorsToProcess(invocation, methodMock)
-				.ForEach(behavior => behavior.Process(invocation));
-
-			return methodMock;
-		}
-
-		private static List<IBehavior> GetBehaviorsToProcess(Invocation invocation, IMethodMock methodMock)
-		{
-			var behaviorsToExecute = new List<IBehavior>();
-
-			var behaviorTypesToSkip = GetBehaviorTypesToSkip(invocation);
-			behaviorsToExecute.AddRange(
-				methodMock.Behaviors.Where(behavior => !behaviorTypesToSkip.Contains(behavior.GetType())));
+			foreach (var behavior in methodMock.Behaviors)
+				behavior.Process(invocation);
 
 			var mock = invocation.MockMixin;
 			if (mock != null)
 			{
-				behaviorsToExecute.AddRange(mock.SupplementaryBehaviors);
+				foreach (var behavior in mock.SupplementaryBehaviors)
+					behavior.Process(invocation);
 			}
-
-			return behaviorsToExecute;
-		}
-
-		private static List<Type> GetBehaviorTypesToSkip(Invocation invocation)
-		{
-			var behaviorTypesToSkip = new List<Type>();
-
-			if (invocation.InAssertSet)
-			{
-				behaviorTypesToSkip.Add(typeof(InvocationOccurrenceBehavior));
-			}
-
-			return behaviorTypesToSkip;
+			return methodMock;
 		}
 
 		private bool TryCreateDelegate(Type type, MockCreationSettings settings, out object delegateResult)

--- a/Telerik.JustMock/Mock.Assert.cs
+++ b/Telerik.JustMock/Mock.Assert.cs
@@ -1,6 +1,6 @@
 ﻿/*
  JustMock Lite
- Copyright © 2010-2015,2018 Telerik EAD
+ Copyright © 2010-2015 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertSetAction(message, action);
+				MockingContext.CurrentRepository.AssertAction(message, action);
 			});
 		}
 
@@ -185,7 +185,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertSetAction(message, action, null, occurs);
+				MockingContext.CurrentRepository.AssertAction(message, action, null, occurs);
 			});
 		}
 
@@ -198,7 +198,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertSetAction(message, action, args, null);
+				MockingContext.CurrentRepository.AssertAction(message, action, args, null);
 			});
 		}
 
@@ -212,7 +212,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertSetAction(message, action, args, occurs);
+				MockingContext.CurrentRepository.AssertAction(message, action, args, occurs);
 			});
 		}
 


### PR DESCRIPTION
Reverts telerik/JustMockLite#39. Due to a problem building the portable solution.