### PR TITLE
Fix AssertSet can't verify the occurrence of a property set when a result of a mocked object is used as a value

### DIFF
--- a/Telerik.JustMock.Tests/AssertionFixture.cs
+++ b/Telerik.JustMock.Tests/AssertionFixture.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015 Telerik EAD
+ Copyright © 2010-2015,2018 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -1117,6 +1117,7 @@ namespace Telerik.JustMock.Tests
             Mock.AssertSet(() => fooMock.Value = bar.Echo(1), Occurs.Never());
         }
     }
+
 #if !XUNIT
 #if !PORTABLE
 #if !NUNIT

--- a/Telerik.JustMock.Tests/AssertionFixture.cs
+++ b/Telerik.JustMock.Tests/AssertionFixture.cs
@@ -1064,7 +1064,59 @@ namespace Telerik.JustMock.Tests
 				DebugView.IsTraceEnabled = traceEnabled;
 			}
 		}
-	}
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
+        public void ShouldAssertSetUsingRighsideLamdaMockResultOccursOnce()
+        {
+            // Arrange
+            var fooMock = Mock.Create<IFoo>();
+            var barMock = Mock.Create<Bar>();
+            Mock.Arrange(() => barMock.Echo(Arg.IsAny<int>())).Returns(2);
+
+            // Act
+            fooMock.Value = barMock.Echo(1);
+
+            // Assert
+            Mock.AssertSet(() => fooMock.Value = barMock.Echo(1), Occurs.Once());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
+        public void ShouldAssertSetUsingRighsideLamdaMockResultOccursNever()
+        {
+            // Arrange
+            var fooMock = Mock.Create<IFoo>();
+            var barMock = Mock.Create<Bar>();
+            Mock.Arrange(() => barMock.Echo(Arg.IsAny<int>())).Returns(2);
+
+            // Assert
+            Mock.AssertSet(() => fooMock.Value = barMock.Echo(1), Occurs.Never());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
+        public void ShouldAssertSetUsingRighsideLamdaUnmockedResultOccursOnce()
+        {
+            // Arrange
+            var fooMock = Mock.Create<IFoo>();
+            var bar = new Bar();
+
+            // Act
+            fooMock.Value = bar.Echo(1);
+
+            // Assert
+            Mock.AssertSet(() => fooMock.Value = bar.Echo(1), Occurs.Once());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Assertion")]
+        public void ShouldAssertSetUsingRighsideLamdaUnmockedResultOccursNever()
+        {
+            // Arrange
+            var fooMock = Mock.Create<IFoo>();
+            var bar = new Bar();
+
+            // Assert
+            Mock.AssertSet(() => fooMock.Value = bar.Echo(1), Occurs.Never());
+        }
+    }
 #if !XUNIT
 #if !PORTABLE
 #if !NUNIT

--- a/Telerik.JustMock/Core/Invocation.cs
+++ b/Telerik.JustMock/Core/Invocation.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015 Telerik EAD
+ Copyright © 2010-2015,2018 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Telerik.JustMock/Core/Invocation.cs
+++ b/Telerik.JustMock/Core/Invocation.cs
@@ -59,6 +59,7 @@ namespace Telerik.JustMock.Core
 		#endregion
 
 		internal bool InArrange { get; set; }
+		internal bool InAssertSet { get; set; }
 		internal bool Recording { get; set; }
 		internal bool RetainBehaviorDuringRecording { get; set; }
 		internal MocksRepository Repository { get; set; }

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -425,7 +425,10 @@ namespace Telerik.JustMock.Core
 						mock.FallbackBehaviors
 							.Where(behavior => !invocation.InAssertSet || !(behavior is CallOriginalBehavior))
 							.ToList();
-					fallbackBehaviorsToExecute.ForEach(behavior => behavior.Process(invocation));
+					foreach (var fallbackBehavior in fallbackBehaviorsToExecute)
+					{
+						fallbackBehavior.Process(invocation);
+					}
 				}
 				else
 				{
@@ -1651,8 +1654,11 @@ namespace Telerik.JustMock.Core
 
 			methodMock.IsUsed = true; //used to correctly determine inSequence arranges
 
-			GetBehaviorsToProcess(invocation, methodMock)
-				.ForEach(behavior => behavior.Process(invocation));
+			var behaviorsToProcess = GetBehaviorsToProcess(invocation, methodMock);
+			foreach (var behavior in behaviorsToProcess)
+			{
+				behavior.Process(invocation);
+			}
 
 			return methodMock;
 		}

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015 Telerik EAD
+ Copyright © 2010-2015,2108 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -92,16 +92,16 @@ namespace Telerik.JustMock.Core
 
 		internal static IMockMixin GetMockMixin(object obj, Type objType)
 		{
-            IMockMixin asMixin = GetMockMixinFromAnyMock(obj);
-            if (asMixin != null)
-            {
-                return asMixin;
-            }
+			IMockMixin asMixin = GetMockMixinFromAnyMock(obj);
+			if (asMixin != null)
+			{
+				return asMixin;
+			}
 
-            if (obj != null && objType == null)
-            {
-                objType = obj.GetType();
-            }
+			if (obj != null && objType == null)
+			{
+				objType = obj.GetType();
+			}
 
 			if (obj != null)
 			{
@@ -287,7 +287,7 @@ namespace Telerik.JustMock.Core
 			while (queue.Count > 0)
 			{
 				MatcherNodeAndParent current = queue.Dequeue();
-                IMatcherTreeNode newCurrent = current.Node.Clone();
+				IMatcherTreeNode newCurrent = current.Node.Clone();
 				foreach (IMatcherTreeNode node in current.Node.Children)
 				{
 					queue.Enqueue(new MatcherNodeAndParent(node, newCurrent));
@@ -309,20 +309,20 @@ namespace Telerik.JustMock.Core
 
 			if (parentRepository != null)
 			{
-                foreach (var root in parentRepository.arrangementTreeRoots)
-                {
-                    this.arrangementTreeRoots.Add(root.Key, DeepCopy(root.Value));
-                }
+				foreach (var root in parentRepository.arrangementTreeRoots)
+				{
+					this.arrangementTreeRoots.Add(root.Key, DeepCopy(root.Value));
+				}
 
-                foreach (var root in parentRepository.invocationTreeRoots)
-                {
-                    this.invocationTreeRoots.Add(root.Key, DeepCopy(root.Value));
-                }
+				foreach (var root in parentRepository.invocationTreeRoots)
+				{
+					this.invocationTreeRoots.Add(root.Key, DeepCopy(root.Value));
+				}
 
-                foreach (var kvp in parentRepository.valueStore)
-                {
-                    this.valueStore.Add(kvp.Key, kvp.Value);
-                }
+				foreach (var kvp in parentRepository.valueStore)
+				{
+					this.valueStore.Add(kvp.Key, kvp.Value);
+				}
 
 				foreach (WeakReference mockRef in parentRepository.controlledMocks)
 				{
@@ -354,18 +354,18 @@ namespace Telerik.JustMock.Core
 		{
 			DebugView.TraceEvent(IndentLevel.Configuration, () => String.Format("Resetting mock repository related to {0}.", this.method));
 
-            foreach (var type in this.arrangedTypes)
-            {
-                ProfilerInterceptor.EnableInterception(type, false, this);
-            }
+			foreach (var type in this.arrangedTypes)
+			{
+				ProfilerInterceptor.EnableInterception(type, false, this);
+			}
 
-            this.arrangedTypes.Clear();
+			this.arrangedTypes.Clear();
 			this.staticMixinDatabase.Clear();
 
-            foreach (var method in this.globallyInterceptedMethods)
-            {
-                ProfilerInterceptor.UnregisterGlobalInterceptor(method, this);
-            }
+			foreach (var method in this.globallyInterceptedMethods)
+			{
+				ProfilerInterceptor.UnregisterGlobalInterceptor(method, this);
+			}
 			this.globallyInterceptedMethods.Clear();
 
 			lock (externalMixinDatabase)
@@ -416,14 +416,16 @@ namespace Telerik.JustMock.Core
 
 			if (!methodMockProcessed)
 			{
-				// We have to be cearfull for the potential exception throwing in the assertion context, so skip CallOriginalBehavior processing
+				// We have to be careful for the potential exception throwing in the assertion context,
+				// so skip CallOriginalBehavior processing
 				var mock = invocation.MockMixin;
 				if (mock != null)
 				{
-                    mock.FallbackBehaviors
-                        .Where(behavior => !invocation.InAssertSet || !(behavior is CallOriginalBehavior))
-                        .ToList()
-                        .ForEach(behavior => behavior.Process(invocation));
+					var fallbackBehaviorsToExecute =
+						mock.FallbackBehaviors
+							.Where(behavior => !invocation.InAssertSet || !(behavior is CallOriginalBehavior))
+							.ToList();
+					fallbackBehaviorsToExecute.ForEach(behavior => behavior.Process(invocation));
 				}
 				else
 				{
@@ -438,14 +440,14 @@ namespace Telerik.JustMock.Core
 		internal T GetValue<T>(object owner, object key, T dflt)
 		{
 			object value;
-            if (valueStore.TryGetValue(new KeyValuePair<object, object>(owner, key), out value))
-            {
-                return (T)value;
-            }
-            else
-            {
-                return dflt;
-            }
+			if (valueStore.TryGetValue(new KeyValuePair<object, object>(owner, key), out value))
+			{
+				return (T)value;
+			}
+			else
+			{
+				return dflt;
+			}
 		}
 
 		internal void StoreValue<T>(object owner, object key, T value)
@@ -460,19 +462,19 @@ namespace Telerik.JustMock.Core
 
 		internal void AddMatcherInContext(IMatcher matcher)
 		{
-            if (!this.sharedContext.InArrange || this.sharedContext.Recorder != null)
-            {
-                this.matchersInContext.Add(matcher);
-            }
+			if (!this.sharedContext.InArrange || this.sharedContext.Recorder != null)
+			{
+				this.matchersInContext.Add(matcher);
+			}
 		}
 
 		internal object Create(Type type, MockCreationSettings settings)
 		{
 			object delegateResult;
-            if (TryCreateDelegate(type, settings, out delegateResult))
-            {
-                return delegateResult;
-            }
+			if (TryCreateDelegate(type, settings, out delegateResult))
+			{
+				return delegateResult;
+			}
 
 			bool isSafeMock = settings.FallbackBehaviors.OfType<CallOriginalBehavior>().Any();
 			this.CheckIfCanMock(type, !isSafeMock);
@@ -514,7 +516,7 @@ namespace Telerik.JustMock.Core
 				}
 			}
 
-            IMockMixin mockMixin = instance as IMockMixin;
+			IMockMixin mockMixin = instance as IMockMixin;
 
 			if (instance == null)
 			{
@@ -807,7 +809,7 @@ namespace Telerik.JustMock.Core
 		{
 			using (MockingContext.BeginFailureAggregation(message))
 			{
-				var callPattern = ConvertActionToCallPattern(memberAction, true);
+				var callPattern = ConvertActionToCallPattern(memberAction);
 				AssertForCallPattern(callPattern, args, occurs);
 			}
 		}
@@ -1649,8 +1651,8 @@ namespace Telerik.JustMock.Core
 
 			methodMock.IsUsed = true; //used to correctly determine inSequence arranges
 
-            GetBehaviorsToProcess(invocation, methodMock)
-                .ForEach(behavior => behavior.Process(invocation));
+			GetBehaviorsToProcess(invocation, methodMock)
+				.ForEach(behavior => behavior.Process(invocation));
 
 			return methodMock;
 		}

--- a/Telerik.JustMock/Core/RepositorySharedContext.cs
+++ b/Telerik.JustMock/Core/RepositorySharedContext.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015 Telerik EAD
+ Copyright © 2010-2015,2018 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ namespace Telerik.JustMock.Core
 		private readonly ThreadLocalProperty<IRecorder> recorder = new ThreadLocalProperty<IRecorder>();
 		private readonly ThreadLocalProperty<object> inArrange = new ThreadLocalProperty<object>();
 		private readonly ThreadLocalProperty<object> dispatchToMethodMocks = new ThreadLocalProperty<object>();
-        private readonly ThreadLocalProperty<object> inAssertSet = new ThreadLocalProperty<object>();
+		private readonly ThreadLocalProperty<object> inAssertSet = new ThreadLocalProperty<object>();
 
 		public IRecorder Recorder
 		{
@@ -43,13 +43,13 @@ namespace Telerik.JustMock.Core
 			private set { this.inArrange.Set(value ? (object)value : null); }
 		}
 
-        public bool InAssertSet
-        {
-            get { return this.inAssertSet.Get() != null; }
-            private set { this.inAssertSet.Set(value ? (object)value : null); }
-        }
+		public bool InAssertSet
+		{
+			get { return this.inAssertSet.Get() != null; }
+			private set { this.inAssertSet.Set(value ? (object)value : null); }
+		}
 
-        public bool DispatchToMethodMocks
+		public bool DispatchToMethodMocks
 		{
 			get { return this.dispatchToMethodMocks.Get() != null; }
 			private set { this.dispatchToMethodMocks.Set(value ? (object)value : null); }
@@ -69,38 +69,38 @@ namespace Telerik.JustMock.Core
 			return new InArrangeContext(this);
 		}
 
-        public IDisposable StartAssertSet()
-        {
-            Monitor.Enter(this);
-            return new InAssertSetContext(this);
-        }
+		public IDisposable StartAssertSet()
+		{
+			Monitor.Enter(this);
+			return new InAssertSetContext(this);
+		}
 
-        public int GetNextArrangeId()
+		public int GetNextArrangeId()
 		{
 			lock (this)
 				return nextArrangeId++;
 		}
 
-        abstract private class ContextSession : IDisposable
-        {
-            private readonly RepositorySharedContext context;
+		abstract private class ContextSession : IDisposable
+		{
+			private readonly RepositorySharedContext context;
 
-            public RepositorySharedContext Context { get { return context; } }
+			public RepositorySharedContext Context { get { return context; } }
 
-            public ContextSession(RepositorySharedContext context)
-            {
-                this.context = context;
-            }
+			public ContextSession(RepositorySharedContext context)
+			{
+				this.context = context;
+			}
 
-            public abstract void Dispose();
-        }
+			public abstract void Dispose();
+		}
 
 		private class InRecordingContext : ContextSession
 		{
 			private readonly int oldCounter;
 
 			public InRecordingContext(RepositorySharedContext context)
-                : base(context)
+				: base(context)
 			{
 				this.oldCounter = ProfilerInterceptor.ReentrancyCounter;
 
@@ -119,7 +119,7 @@ namespace Telerik.JustMock.Core
 		private class InArrangeContext : ContextSession
 		{
 			public InArrangeContext(RepositorySharedContext context)
-                : base(context)
+				: base(context)
 			{
 				Debug.Assert(!this.Context.InArrange);
 				context.InArrange = true;
@@ -132,20 +132,20 @@ namespace Telerik.JustMock.Core
 			}
 		}
 
-        private class InAssertSetContext : ContextSession
-        {
-            public InAssertSetContext(RepositorySharedContext context)
-                : base(context)
-            {
-                Debug.Assert(!this.Context.InAssertSet);
-                context.InAssertSet = true;
-            }
+		private class InAssertSetContext : ContextSession
+		{
+			public InAssertSetContext(RepositorySharedContext context)
+				: base(context)
+			{
+				Debug.Assert(!this.Context.InAssertSet);
+				context.InAssertSet = true;
+			}
 
-            public override void Dispose()
-            {
-                this.Context.InAssertSet = false;
-                Monitor.Exit(this.Context);
-            }
-        }
-    }
+			public override void Dispose()
+			{
+				this.Context.InAssertSet = false;
+				Monitor.Exit(this.Context);
+			}
+		}
+	}
 }

--- a/Telerik.JustMock/Mock.Assert.cs
+++ b/Telerik.JustMock/Mock.Assert.cs
@@ -172,7 +172,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertAction(message, action);
+				MockingContext.CurrentRepository.AssertSetAction(message, action);
 			});
 		}
 
@@ -185,7 +185,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertAction(message, action, null, occurs);
+				MockingContext.CurrentRepository.AssertSetAction(message, action, null, occurs);
 			});
 		}
 
@@ -198,7 +198,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertAction(message, action, args, null);
+				MockingContext.CurrentRepository.AssertSetAction(message, action, args, null);
 			});
 		}
 
@@ -212,7 +212,7 @@ namespace Telerik.JustMock
 		{
 			ProfilerInterceptor.GuardInternal(() =>
 			{
-				MockingContext.CurrentRepository.AssertAction(message, action, args, occurs);
+				MockingContext.CurrentRepository.AssertSetAction(message, action, args, occurs);
 			});
 		}
 

--- a/Telerik.JustMock/Mock.Assert.cs
+++ b/Telerik.JustMock/Mock.Assert.cs
@@ -1,6 +1,6 @@
 ﻿/*
  JustMock Lite
- Copyright © 2010-2015 Telerik EAD
+ Copyright © 2010-2015,2018 Telerik EAD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
o enabled dispatching invocation to mocks
o introduced new property in Invocation indicating AssertSet context
o adjusted some behavior processing in AssertSet scope
o added unit tests to cover the change

Replays telerik/JustMockLite#44 reverted due to wrong target