### PR TITLE
Using JustMock with NCrunch and xUnit1 leads to unexpected exception

### DIFF
--- a/Telerik.JustMock/Core/Context/MbUnitContextResolver.cs
+++ b/Telerik.JustMock/Core/Context/MbUnitContextResolver.cs
@@ -21,10 +21,11 @@ namespace Telerik.JustMock.Core.Context
 {
 	internal class MbUnitContextResolver : HierarchicalTestFrameworkContextResolver
 	{
-		private const string MbUnitAssertionFailedName = "Gallio.Framework.Assertions.AssertionException, gallio";
+		private const string MbUnitTestFixtureAttributeName = "MbUnit.FrameworkTestFixtureAttribute, mbunit";
+		private const string GalioAssertionFailedName = "Gallio.Framework.Assertions.AssertionException, gallio";
 
 		public MbUnitContextResolver()
-			: base(MbUnitAssertionFailedName)
+			: base(GalioAssertionFailedName)
 		{
 			SetupStandardHierarchicalTestStructure(
 				new[] { "Gallio.Framework.Pattern.TestMethodPatternAttribute, gallio" },
@@ -36,7 +37,8 @@ namespace Telerik.JustMock.Core.Context
 
 		public static bool IsAvailable
 		{
-			get { return FindType(MbUnitAssertionFailedName, false) != null; }
+			get { return FindType(MbUnitTestFixtureAttributeName, false) != null
+					&& FindType(GalioAssertionFailedName, false) != null; }
 		}
 	}
 }


### PR DESCRIPTION
o improved MbUnitContextResolver availability check