### PR TITLE
Fix a regression when mocking type that implement SerializableAttribute and ISerializable interface

### DIFF
--- a/Telerik.JustMock.DemoLib/FooImplementFullSerialization.cs
+++ b/Telerik.JustMock.DemoLib/FooImplementFullSerialization.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Telerik.JustMock.DemoLib
+{
+    [Serializable]
+    public class FooImplementSerializationAttributeAndInterface : ISerializable
+    {
+        public virtual int Value { get; set; }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Telerik.JustMock.DemoLib/FooInheritISerializable.cs
+++ b/Telerik.JustMock.DemoLib/FooInheritISerializable.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Telerik.JustMock.DemoLib
+{
+    public class FooInheritISerializable : ISerializable
+    {
+        public virtual int Value { get; set; }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Telerik.JustMock.DemoLib/FooSerializable.cs
+++ b/Telerik.JustMock.DemoLib/FooSerializable.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Telerik.JustMock.DemoLib
+{
+    [Serializable]
+    public class FooSerializable
+    {
+        public virtual int Value { get; set; }
+    }
+}

--- a/Telerik.JustMock.Tests/SerializableFixture.cs
+++ b/Telerik.JustMock.Tests/SerializableFixture.cs
@@ -1,0 +1,94 @@
+﻿/*
+ JustMock Lite
+ Copyright © 2019 Progress Software Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Telerik.JustMock.DemoLib;
+
+#region JustMock Test Attributes
+#if NUNIT
+using NUnit.Framework;
+using TestCategory = NUnit.Framework.CategoryAttribute;
+using TestClass = NUnit.Framework.TestFixtureAttribute;
+using TestMethod = NUnit.Framework.TestAttribute;
+using TestInitialize = NUnit.Framework.SetUpAttribute;
+using TestCleanup = NUnit.Framework.TearDownAttribute;
+using AssertionException = NUnit.Framework.AssertionException;
+#elif XUNIT
+using Xunit;
+using Telerik.JustMock.XUnit.Test.Attributes;
+using TestCategory = Telerik.JustMock.XUnit.Test.Attributes.XUnitCategoryAttribute;
+using TestClass = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestClassAttribute;
+using TestMethod = Xunit.FactAttribute;
+using TestInitialize = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestInitializeAttribute;
+using TestCleanup = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestCleanupAttribute;
+#if XUNIT2
+using AssertionException = Xunit.Sdk.XunitException;
+#else
+using AssertionException = Xunit.Sdk.AssertException;
+#endif
+#elif VSTEST_PORTABLE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using AssertionException = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.AssertFailedException;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AssertionException = Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException;
+#endif
+#endregion
+
+namespace Telerik.JustMock.Tests
+{
+    [TestClass]
+    public class SerializableFixture
+    {
+        [TestMethod, TestCategory("Lite"), TestCategory("Serializable")]
+        public void ShouldMockTypesMarkedWithSerializableAttribute()
+        {
+            int expected = 10;
+            var foo = Mock.Create<FooSerializable>();
+
+            Mock.Arrange(() => foo.Value).Returns(expected);
+
+            var actual = foo.Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Serializable")]
+        public void ShouldMockTypesThatInheritISerializable()
+        {
+            int expected = 10;
+            var foo = Mock.Create<FooInheritISerializable>();
+
+            Mock.Arrange(() => foo.Value).Returns(expected);
+
+            var actual = foo.Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("Serializable")]
+        public void ShouldMockTypeThatImplementSerializationAttributeAndInterface()
+        {
+            int expected = 10;
+            var foo = Mock.Create<FooImplementSerializationAttributeAndInterface>();
+
+            Mock.Arrange(() => foo.Value).Returns(expected);
+
+            var actual = foo.Value;
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Telerik.JustMock.Tests/Telerik.JustMock.Tests.projitems
+++ b/Telerik.JustMock.Tests/Telerik.JustMock.Tests.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RecursiveFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReturnsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SequenceFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SerializableFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WaitEventFixture.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Telerik.JustMock/Telerik.JustMock.csproj
+++ b/Telerik.JustMock/Telerik.JustMock.csproj
@@ -50,7 +50,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);FEATURE_REMOTING;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_REMOTING;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>


### PR DESCRIPTION
Fixing a regression problem related to mocking a type that implements both  SerializableAttribute attribute and ISerializable interface. The issue is also related to updating the used version of DynamicProxy.