### PR TITLE
The static constructor of a type disrespects previously created arragements when triggered by the Telerik.JustMock.PrivateAccessor class

### DIFF
--- a/Telerik.JustMock/PrivateAccessor.cs
+++ b/Telerik.JustMock/PrivateAccessor.cs
@@ -105,7 +105,9 @@ namespace Telerik.JustMock
 						type = type.BaseType;
 					}
 
+#if (!PORTABLE && !LITE_EDITION)
 					Mock.Intercept(type);
+#endif
 				});
 
 			this.instance = instance;
@@ -522,8 +524,8 @@ namespace Telerik.JustMock
 #if (COREFX)
 			return false;
 #else
-            try
-            {
+			try
+			{
 				new ReflectionPermission(ReflectionPermissionFlag.MemberAccess).Demand();
 				return true;
 			}

--- a/Telerik.JustMock/PrivateAccessor.cs
+++ b/Telerik.JustMock/PrivateAccessor.cs
@@ -1,6 +1,6 @@
 /*
  JustMock Lite
- Copyright © 2010-2015,2018 Progress Software Corporation
+ Copyright © 2010-2015,2018-2019 Progress Software Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -94,12 +94,18 @@ namespace Telerik.JustMock
 #if (!COREFX && !NETCORE)
 						var realProxy = MockingProxy.GetRealProxy(instance);
 						if (realProxy != null)
+						{
 							instance = realProxy.WrappedInstance;
+						}
 #endif
 						type = instance.GetType();
 					}
 					if (type.IsProxy() && type.BaseType != typeof(object))
+					{
 						type = type.BaseType;
+					}
+
+					Mock.Intercept(type);
 				});
 
 			this.instance = instance;


### PR DESCRIPTION
o added call to Mock.Intercept in the private constructor of the PrivateAccessor class