### PR TITLE
Mocking a static method not directly used in a test execution logic messes with the arrangements of the test

### DIFF
--- a/Telerik.JustMock/Core/Behaviors/RecursiveMockingBehavior.cs
+++ b/Telerik.JustMock/Core/Behaviors/RecursiveMockingBehavior.cs
@@ -121,6 +121,12 @@ namespace Telerik.JustMock.Core.Behaviors
 #endif
 			}
 
+			// mock invocations in static constructors according to the behavior
+			if (invocation.InRunClassConstructor)
+			{
+				return invocation.InArrange && !invocation.CallOriginal;
+			}
+
 			return invocation.InArrange && !invocation.InArrangeArgMatching || this.type == RecursiveMockingBehaviorType.ReturnMock;
 		}
 

--- a/Telerik.JustMock/Core/Invocation.cs
+++ b/Telerik.JustMock/Core/Invocation.cs
@@ -61,6 +61,7 @@ namespace Telerik.JustMock.Core
 		internal bool InArrange { get; set; }
 		internal bool InArrangeArgMatching { get; set; }
 		internal bool InAssertSet { get; set; }
+		internal bool InRunClassConstructor { get; set; }
 		internal bool Recording { get; set; }
 		internal bool RetainBehaviorDuringRecording { get; set; }
 

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -383,6 +383,7 @@ namespace Telerik.JustMock.Core
             invocation.InArrange = this.sharedContext.InArrange;
             invocation.InArrangeArgMatching = this.sharedContext.InArrangeArgMatching;
             invocation.InAssertSet = this.sharedContext.InAssertSet;
+            invocation.InRunClassConstructor = this.sharedContext.RunClassConstructorCount > 0;
             invocation.Recording = this.Recorder != null;
             invocation.RetainBehaviorDuringRecording = this.sharedContext.DispatchToMethodMocks;
             invocation.Repository = this;
@@ -1223,10 +1224,13 @@ namespace Telerik.JustMock.Core
                         break;
                 }
 
-                var handle = typeToIntercept.TypeHandle;
-                this.disabledTypes.Add(typeof(RuntimeHelpers));
-                ProfilerInterceptor.RunClassConstructor(handle);
-                this.disabledTypes.Remove(typeof(RuntimeHelpers));
+                using (this.sharedContext.StartRunClassConstructor())
+                {
+                    var handle = typeToIntercept.TypeHandle;
+                    this.disabledTypes.Add(typeof(RuntimeHelpers));
+                    ProfilerInterceptor.RunClassConstructor(handle);
+                    this.disabledTypes.Remove(typeof(RuntimeHelpers));
+                }
             }
         }
 


### PR DESCRIPTION
o changed RecursiveMockingBehavior.MustReturnMock to create mocks in static constructors according to Invocation.CallOriginal property