### PR TITLE
Fix documentation build

### DIFF
--- a/Telerik.JustMock/Expectations/Abstraction/INonPublicExpectation.cs
+++ b/Telerik.JustMock/Expectations/Abstraction/INonPublicExpectation.cs
@@ -135,7 +135,6 @@ namespace Telerik.JustMock.Expectations.Abstraction
         /// Asserts the specified member that it is called as expected.
         /// </summary>
         /// <param name="target">Target mock</param>
-        /// <param name="args">Method arguments</param>
         /// <param name="memberName">Name of the member</param>
         /// <typeparam name="TReturn">Return type of the method</typeparam>
         /// <param name="args">Method arguments</param>


### PR DESCRIPTION
o fixed duplicate parameter names causing NullReferenceException (issue #4165 on GitHub dotnet/docfx repo)