### PR TITLE
PrivateAccessor.CallMethod throws AmbiguousMatchException when called with null arguments

### DIFF
--- a/Telerik.JustMock/Core/MockingUtil.CodeGen.cs
+++ b/Telerik.JustMock/Core/MockingUtil.CodeGen.cs
@@ -1,6 +1,6 @@
 ﻿/*
  JustMock Lite
- Copyright © 2010-2015 Progress Software Corporation
+ Copyright © 2010-2015,2020 Progress Software Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -182,6 +182,11 @@ namespace Telerik.JustMock.Core
 			ParameterModifier[] modifiers, CultureInfo culture, string[] names, out Object state)
 		{
 			return Type.DefaultBinder.BindToMethod(bindingAttr, match, ref args, modifiers, culture, names, out state);
+		}
+
+		public static MethodBase SelectMethod(BindingFlags bindingAttr, MethodBase[] match, Type[] types, ParameterModifier[] modifiers)
+		{
+			return Type.DefaultBinder.SelectMethod(bindingAttr, match, types, modifiers);
 		}
 
 		private static int? GetDispId(MemberInfo member)

--- a/Telerik.JustMock/PrivateAccessor.cs
+++ b/Telerik.JustMock/PrivateAccessor.cs
@@ -177,12 +177,10 @@ namespace Telerik.JustMock
                 throw new ArgumentNullException("argTypes");
             }
 
-            argValues =
-                argValues == null || argValues.Length == 0
-                    ?
-                        argTypes.Select(t => MockingUtil.GetDefaultValue(t)).ToArray()
-                        :
-                        argValues;
+            if (argValues == null || argValues.Length == 0)
+            {
+                argValues = argTypes.Select(t => MockingUtil.GetDefaultValue(t)).ToArray();
+            }
 
             if (argTypes.Count != argValues.Length)
             {


### PR DESCRIPTION
o extended API with a new method