### PR TITLE
InOrder arrangement clause cannot accept more than one call of the arranged method subsequently

### DIFF
--- a/Telerik.JustMock/Core/Behaviors/InOrderBehavior.cs
+++ b/Telerik.JustMock/Core/Behaviors/InOrderBehavior.cs
@@ -78,7 +78,12 @@ namespace Telerik.JustMock.Core.Behaviors
 		public void Process(Invocation invocation)
 		{
 			this.wasCalled = true;
-			this.calledInWrongOrder = (this.LastIdInOrder != this.arrangementId - 1);
+
+			bool processedOnce = this.LastIdInOrder > -1;
+			this.calledInWrongOrder =
+				processedOnce
+				&& (this.LastIdInOrder - this.arrangementId) > 0 || (this.LastIdInOrder - this.arrangementId) < -1;
+
 			this.LastIdInOrder = this.arrangementId;
 
 			this.InOrderExecutionLog += invocation.InputToString() + " called at:\n" + MockingContext.GetStackTrace("    ");


### PR DESCRIPTION
o handled case when required repeated in order calls