### PR TITLE
InOrder arrangement clause cannot accept more than one call of the arranged method subsequently

### DIFF
--- a/Telerik.JustMock/Core/IMethodMock.cs
+++ b/Telerik.JustMock/Core/IMethodMock.cs
@@ -30,6 +30,7 @@ namespace Telerik.JustMock.Core
 		InvocationOccurrenceBehavior OccurencesBehavior { get; }
 		string ArrangementExpression { get; set; }
 		bool IsSequential { get; set; }
+		bool IsInOrder { get; set; }
 		bool IsUsed { get; set; }
 		ImplementationOverrideBehavior AcceptCondition { get; set; }
 	}

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -1539,7 +1539,9 @@ namespace Telerik.JustMock.Core
         private IMethodMock GetMethodMockFromNodes(List<MethodMockMatcherTreeNode> methodMockNodes, Invocation invocation)
         {
             if (methodMockNodes.Count == 0)
+            {
                 return null;
+            }
 
             var resultsQ =
                 from node in methodMockNodes
@@ -1552,15 +1554,25 @@ namespace Telerik.JustMock.Core
 
             var resultList = resultsQ.ToList();
 
-            var nonSequential = resultList.Where(x => !x.MethodMock.IsSequential && x.Acceptable).LastOrDefault();
-            if (nonSequential != null)
-                return nonSequential.MethodMock;
+            var nonSequentialOrInOrder = resultList.Where(x => !x.MethodMock.IsSequential && !x.MethodMock.IsInOrder && x.Acceptable).LastOrDefault();
+            if (nonSequentialOrInOrder != null)
+            {
+                return nonSequentialOrInOrder.MethodMock;
+            }
+
+            var inOrder = resultList.Where(x => x.MethodMock.IsInOrder && !x.MethodMock.IsUsed && x.Acceptable).FirstOrDefault();
+            if (inOrder != null)
+            {
+                return inOrder.MethodMock;
+            }
 
             var sequential = resultList.Where(x => x.MethodMock.IsSequential && !x.MethodMock.IsUsed && x.Acceptable).FirstOrDefault();
             if (sequential != null)
+            {
                 return sequential.MethodMock;
+            }
 
-            return resultList.Where(x => x.MethodMock.IsSequential && x.Acceptable).Select(x => x.MethodMock).LastOrDefault();
+            return resultList.Where(x => (x.MethodMock.IsSequential || x.MethodMock.IsInOrder) && x.Acceptable).Select(x => x.MethodMock).LastOrDefault();
         }
 
         internal string GetDebugView(object mock = null)

--- a/Telerik.JustMock/Expectations/CommonExpectation.cs
+++ b/Telerik.JustMock/Expectations/CommonExpectation.cs
@@ -41,7 +41,8 @@ namespace Telerik.JustMock.Expectations
 		IMockMixin IMethodMock.Mock { get; set; }
 
 		bool IMethodMock.IsSequential { get; set; }
-		bool IMethodMock.IsUsed { get; set; }
+        bool IMethodMock.IsInOrder { get; set; }
+        bool IMethodMock.IsUsed { get; set; }
 		CallPattern IMethodMock.CallPattern { get; set; }
 		ICollection<IBehavior> IMethodMock.Behaviors { get { return this.behaviors; } }
 		InvocationOccurrenceBehavior IMethodMock.OccurencesBehavior { get { return this.occurences; } }
@@ -441,7 +442,8 @@ namespace Telerik.JustMock.Expectations
 		{
 			return ProfilerInterceptor.GuardInternal(() =>
 				{
-					this.behaviors.Add(new InOrderBehavior(this.Repository, this.Mock, message));
+                    (this as IMethodMock).IsInOrder = true;
+                    this.behaviors.Add(new InOrderBehavior(this.Repository, this.Mock, message));
 					return this;
 				});
 		}


### PR DESCRIPTION
o handled case when required repeated in order calls