### PR TITLE
Switch off licensing telemetry for Visual Studio extension

### DIFF
--- a/Telerik.JustMock/Telerik.JustMock.csproj
+++ b/Telerik.JustMock/Telerik.JustMock.csproj
@@ -59,7 +59,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableLicensing)' == 'true' ">
-    <DefineConstants>$(DefineConstants);FEATURE_LICENSING;FEATURE_SEND_LICENSING_TELEMETRY_TOGGLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_LICENSING;FEATURE_SEND_LICENSING_TELEMETRY;FEATURE_SEND_LICENSING_TELEMETRY_TOGGLE</DefineConstants>
     <LicensingBasePath>..\..\CodeBase\Build\Licensing</LicensingBasePath>
     <CallHomePath>..\..\call-home</CallHomePath>
   </PropertyGroup>


### PR DESCRIPTION
o closes telerik/MATTeam#877