### PR TITLE
chore: Add preview target framework to examples

### DIFF
--- a/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.csproj
+++ b/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.csproj
+++ b/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.csproj
@@ -3,9 +3,13 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PreviewTargetFramework)' != '' ">
+    <TargetFrameworks>$(TargetFrameworks);$(PreviewTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.csproj
+++ b/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.csproj
+++ b/Examples/CSExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.csproj
@@ -3,9 +3,13 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PreviewTargetFramework)' != '' ">
+    <TargetFrameworks>$(TargetFrameworks);$(PreviewTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.vbproj
+++ b/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.vbproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.vbproj
+++ b/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2019.vbproj
@@ -3,9 +3,13 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PreviewTargetFramework)' != '' ">
+    <TargetFrameworks>$(TargetFrameworks);$(PreviewTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.vbproj
+++ b/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.vbproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.vbproj
+++ b/Examples/VBExamples/JustMock.NonElevatedExamples/JustMock.NonElevatedExamples.VS2022.vbproj
@@ -3,9 +3,13 @@
   <Import Project="..\..\JustMock.NonElevatedExamples.Common.proj"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PreviewTargetFramework)' != '' ">
+    <TargetFrameworks>$(TargetFrameworks);$(PreviewTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
chore: val/966-add-net10-add-PreviewTargetFramework-to-examples
 
- add PreviewTargetFramework to the examples project files

closes telerik/MATTeam#966