### PR TITLE
Add Mock.ClearInvocations and Mock.Reset per-object overloads

### DIFF
--- a/Telerik.JustMock.Tests/MockClearInvocationsFixture.cs
+++ b/Telerik.JustMock.Tests/MockClearInvocationsFixture.cs
@@ -1,0 +1,336 @@
+﻿/*
+ JustMock Lite
+ Copyright (C) 2010-2024 Progress Software Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System;
+
+#region JustMock Test Attributes
+#if NUNIT
+using NUnit.Framework;
+using TestCategory = NUnit.Framework.CategoryAttribute;
+using TestClass = NUnit.Framework.TestFixtureAttribute;
+using TestMethod = NUnit.Framework.TestAttribute;
+using TestInitialize = NUnit.Framework.SetUpAttribute;
+using TestCleanup = NUnit.Framework.TearDownAttribute;
+using AssertionException = NUnit.Framework.AssertionException;
+#elif XUNIT
+using Xunit;
+using Telerik.JustMock.XUnit.Test.Attributes;
+using TestCategory = Telerik.JustMock.XUnit.Test.Attributes.XUnitCategoryAttribute;
+using TestClass = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestClassAttribute;
+using TestMethod = Xunit.FactAttribute;
+using TestInitialize = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestInitializeAttribute;
+using TestCleanup = Telerik.JustMock.XUnit.Test.Attributes.EmptyTestCleanupAttribute;
+using AssertionException = Telerik.JustMock.XUnit.AssertFailedException;
+#elif VSTEST_PORTABLE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using AssertionException = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.AssertFailedException;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AssertionException = Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException;
+#endif
+#endregion
+
+namespace Telerik.JustMock.Tests
+{
+    [TestClass]
+    public class MockClearInvocationsFixture
+    {
+        public interface IService
+        {
+            void Execute();
+            int GetValue();
+            void Process(string input);
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_ResetsCounterAndArrangementRemains()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.GetValue()).Returns(42);
+
+            Assert.Equal(42, mock.GetValue());
+            Mock.Assert(() => mock.GetValue(), Occurs.Once());
+
+            Mock.ClearInvocations(mock);
+
+            // Invocation counter reset — Occurs.Never() should now pass
+            Mock.Assert(() => mock.GetValue(), Occurs.Never());
+            // Arrangement still active — returns the arranged value
+            Assert.Equal(42, mock.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_MultipleArrangementsAllReset()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).DoNothing();
+            Mock.Arrange(() => mock.GetValue()).Returns(7);
+
+            mock.Execute();
+            mock.Execute();
+            mock.GetValue();
+
+            Mock.ClearInvocations(mock);
+
+            Mock.Assert(() => mock.Execute(), Occurs.Never());
+            Mock.Assert(() => mock.GetValue(), Occurs.Never());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_SiblingMockUnaffected()
+        {
+            var mockA = Mock.Create<IService>();
+            var mockB = Mock.Create<IService>();
+
+            Mock.Arrange(() => mockA.Execute()).DoNothing();
+            Mock.Arrange(() => mockB.Execute()).DoNothing();
+
+            mockA.Execute();
+            mockB.Execute();
+            mockB.Execute();
+
+            Mock.ClearInvocations(mockA);
+
+            // mockA reset
+            Mock.Assert(() => mockA.Execute(), Occurs.Never());
+            // mockB untouched
+            Mock.Assert(() => mockB.Execute(), Occurs.Exactly(2));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_GetTimesCalledReturnsZeroAfterClear()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).DoNothing();
+
+            mock.Execute();
+            mock.Execute();
+            Assert.Equal(2, Mock.GetTimesCalled(() => mock.Execute()));
+
+            Mock.ClearInvocations(mock);
+
+            Assert.Equal(0, Mock.GetTimesCalled(() => mock.Execute()));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_SharedMockPhaseIsolation()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).DoNothing();
+
+            // Phase 1
+            mock.Execute();
+            Mock.Assert(() => mock.Execute(), Occurs.Once());
+
+            Mock.ClearInvocations(mock);
+
+            // Phase 2 — counter starts from zero again; arrangement still active
+            Mock.Assert(() => mock.Execute(), Occurs.Never());
+            mock.Execute();
+            mock.Execute();
+            Mock.Assert(() => mock.Execute(), Occurs.Exactly(2));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_NullThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Mock.ClearInvocations(null));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_NonMockThrowsArgumentException()
+        {
+            var realObject = new object();
+            Assert.Throws<ArgumentException>(() => Mock.ClearInvocations(realObject));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_InOrderResetsSequenceTracking()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).InOrder();
+            Mock.Arrange(() => mock.GetValue()).InOrder();
+
+            // Phase 1 — call in correct order
+            mock.Execute();
+            mock.GetValue();
+            Mock.Assert(mock);
+
+            Mock.ClearInvocations(mock);
+
+            // Phase 2 — same order again should pass (sequence reset)
+            mock.Execute();
+            mock.GetValue();
+            Mock.Assert(mock);
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_InOrderWrongSequenceAfterClearFails()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).InOrder();
+            Mock.Arrange(() => mock.GetValue()).InOrder();
+
+            mock.Execute();
+            mock.GetValue();
+            Mock.Assert(mock);
+
+            Mock.ClearInvocations(mock);
+
+            // Call in wrong order after clear
+            mock.GetValue();
+            mock.Execute();
+            Assert.Throws<AssertionException>(() => Mock.Assert(mock));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_InOrderPartialSequenceAfterClear()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).InOrder().OccursOnce();
+            Mock.Arrange(() => mock.GetValue()).InOrder().OccursOnce();
+            Mock.Arrange(() => mock.Process(Arg.AnyString)).InOrder().OccursOnce();
+
+            mock.Execute();
+            mock.GetValue();
+            mock.Process("test");
+            Mock.Assert(mock);
+
+            Mock.ClearInvocations(mock);
+
+            // After clear, only call first two — third should fail occurs check
+            mock.Execute();
+            mock.GetValue();
+            Assert.Throws<AssertionException>(() => Mock.Assert(mock));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_InOrderMultipleClearCycles()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).InOrder();
+            Mock.Arrange(() => mock.GetValue()).InOrder();
+
+            for (int i = 0; i < 3; i++)
+            {
+                mock.Execute();
+                mock.GetValue();
+                Mock.Assert(mock);
+                Mock.ClearInvocations(mock);
+            }
+
+            // After final clear, no invocations
+            Mock.Assert(() => mock.Execute(), Occurs.Never());
+            Mock.Assert(() => mock.GetValue(), Occurs.Never());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_InOrderSiblingMockSequenceUnaffected()
+        {
+            var mockA = Mock.Create<IService>();
+            var mockB = Mock.Create<IService>();
+
+            Mock.Arrange(() => mockA.Execute()).InOrder();
+            Mock.Arrange(() => mockA.GetValue()).InOrder();
+
+            Mock.Arrange(() => mockB.Execute()).InOrder();
+            Mock.Arrange(() => mockB.GetValue()).InOrder();
+
+            mockA.Execute();
+            mockA.GetValue();
+            mockB.Execute();
+            mockB.GetValue();
+
+            Mock.ClearInvocations(mockA);
+
+            // mockA sequence reset
+            Mock.Assert(() => mockA.Execute(), Occurs.Never());
+            // mockB sequence intact
+            Mock.Assert(mockB);
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_RemovesArrangementsFromMock()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.GetValue()).Returns(99);
+
+            Assert.Equal(99, mock.GetValue());
+
+            Mock.Reset(mock);
+
+            // Arrangement gone — default value returned
+            Assert.Equal(0, mock.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_ClearsInvocationsAlongWithArrangements()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).DoNothing();
+
+            mock.Execute();
+
+            Mock.Reset(mock);
+
+            Mock.Assert(() => mock.Execute(), Occurs.Never());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_SiblingMockArrangementsUnaffected()
+        {
+            var mockA = Mock.Create<IService>();
+            var mockB = Mock.Create<IService>();
+
+            Mock.Arrange(() => mockA.GetValue()).Returns(1);
+            Mock.Arrange(() => mockB.GetValue()).Returns(2);
+
+            Mock.Reset(mockA);
+
+            // mockA arrangement gone
+            Assert.Equal(0, mockA.GetValue());
+            // mockB still arranged
+            Assert.Equal(2, mockB.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_MockRemainsUsableAfterReset()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.GetValue()).Returns(5);
+
+            Mock.Reset(mock);
+
+            // Can re-arrange after reset
+            Mock.Arrange(() => mock.GetValue()).Returns(10);
+            Assert.Equal(10, mock.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_NullThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Mock.Reset((object)null));
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_NonMockThrowsArgumentException()
+        {
+            var realObject = new object();
+            Assert.Throws<ArgumentException>(() => Mock.Reset(realObject));
+        }
+    }
+}

--- a/Telerik.JustMock.Tests/MockClearInvocationsFixture.cs
+++ b/Telerik.JustMock.Tests/MockClearInvocationsFixture.cs
@@ -192,8 +192,7 @@ namespace Telerik.JustMock.Tests
             Mock.ClearInvocations(mock);
 
             // Call in wrong order after clear
-            mock.GetValue();
-            mock.Execute();
+            Assert.Throws<AssertionException>(() => mock.GetValue());
             Assert.Throws<AssertionException>(() => Mock.Assert(mock));
         }
 
@@ -263,6 +262,28 @@ namespace Telerik.JustMock.Tests
             Mock.Assert(mockB);
         }
 
+        [TestMethod, TestCategory("Lite"), TestCategory("ClearInvocations")]
+        public void ClearInvocations_SiblingInOrderWrongSequenceStillFailsAtCallSite()
+        {
+            var mockA = Mock.Create<IService>();
+            var mockB = Mock.Create<IService>();
+
+            Mock.Arrange(() => mockA.Execute()).InOrder();
+            Mock.Arrange(() => mockA.GetValue()).InOrder();
+
+            Mock.Arrange(() => mockB.Execute()).InOrder();
+            Mock.Arrange(() => mockB.GetValue()).InOrder();
+
+            mockA.Execute();
+            mockA.GetValue();
+
+            Mock.ClearInvocations(mockA);
+
+            mockA.Execute();
+
+            Assert.Throws<AssertionException>(() => mockB.GetValue());
+        }
+
         [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
         public void ResetInstance_RemovesArrangementsFromMock()
         {
@@ -318,6 +339,38 @@ namespace Telerik.JustMock.Tests
             // Can re-arrange after reset
             Mock.Arrange(() => mock.GetValue()).Returns(10);
             Assert.Equal(10, mock.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_RearrangedInOrderWrongSequenceFailsAtCallSite()
+        {
+            var mock = Mock.Create<IService>();
+            Mock.Arrange(() => mock.Execute()).InOrder();
+            Mock.Arrange(() => mock.GetValue()).InOrder();
+
+            Mock.Reset(mock);
+
+            Mock.Arrange(() => mock.Execute()).InOrder();
+            Mock.Arrange(() => mock.GetValue()).InOrder();
+
+            Assert.Throws<AssertionException>(() => mock.GetValue());
+        }
+
+        [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]
+        public void ResetInstance_SiblingInOrderWrongSequenceStillFailsAtCallSite()
+        {
+            var mockA = Mock.Create<IService>();
+            var mockB = Mock.Create<IService>();
+
+            Mock.Arrange(() => mockA.Execute()).InOrder();
+            Mock.Arrange(() => mockA.GetValue()).InOrder();
+
+            Mock.Arrange(() => mockB.Execute()).InOrder();
+            Mock.Arrange(() => mockB.GetValue()).InOrder();
+
+            Mock.Reset(mockA);
+
+            Assert.Throws<AssertionException>(() => mockB.GetValue());
         }
 
         [TestMethod, TestCategory("Lite"), TestCategory("ResetInstance")]

--- a/Telerik.JustMock.Tests/Telerik.JustMock.Tests.projitems
+++ b/Telerik.JustMock.Tests/Telerik.JustMock.Tests.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MiscFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockResetFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MockClearInvocationsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NinjectAutoMockFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NonPublicFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OccurrenceFixture.cs" />

--- a/Telerik.JustMock/Core/Behaviors/InOrderBehavior.cs
+++ b/Telerik.JustMock/Core/Behaviors/InOrderBehavior.cs
@@ -88,11 +88,20 @@ namespace Telerik.JustMock.Core.Behaviors
 
             this.InOrderExecutionLog += invocation.InputToString() + " called at:\n" + MockingContext.GetStackTrace("    ");
 
-            if (this.calledInWrongOrder)
+            if (this.calledInWrongOrder && !this.Repository.DeferInOrderViolations)
             {
                 MockingContext.Fail("{0}Last call executed out of order. Order of calls so far:\n{1}",
                     this.message != null ? this.message + " " : "", InOrderExecutionMessage);
             }
+        }
+
+        internal void Reset()
+        {
+            this.wasCalled = false;
+            this.calledInWrongOrder = false;
+            this.Repository.StoreValue(typeof(InOrderBehavior), "count", 0);
+            this.Repository.StoreValue(typeof(InOrderBehavior), "id", -1);
+            this.Repository.StoreValue<string>(typeof(InOrderBehavior), "log", null);
         }
 
         public void Assert()

--- a/Telerik.JustMock/Core/Behaviors/InvocationOccurrenceBehavior.cs
+++ b/Telerik.JustMock/Core/Behaviors/InvocationOccurrenceBehavior.cs
@@ -64,6 +64,12 @@ namespace Telerik.JustMock.Core.Behaviors
             this.message = message;
         }
 
+        internal void Reset()
+        {
+            this.calls = 0;
+        }
+
+
         public void Process(Invocation invocation)
         {
             ++calls;

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -899,6 +899,52 @@ namespace Telerik.JustMock.Core
             }
         }
 
+        internal void ClearInvocations(object instance)
+        {
+            if (instance == null)
+                throw new ArgumentNullException("instance");
+
+            MockingUtil.UnwrapDelegateTarget(ref instance);
+            if (instance == null)
+                throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
+
+            var methodMocks = GetMethodMocksFromObject(instance);
+            if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
+                throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
+
+            foreach (var node in methodMocks)
+            {
+                node.MethodMock.OccurencesBehavior.Reset();
+                node.MethodMock.IsUsed = false;
+            }
+
+            var instanceMatcher = new ReferenceMatcher(instance);
+            foreach (var root in invocationTreeRoots.Values)
+                root.Children.RemoveAll(child => child.Matcher.Equals(instanceMatcher));
+        }
+
+        internal void ResetInstance(object instance)
+        {
+            if (instance == null)
+                throw new ArgumentNullException("instance");
+
+            MockingUtil.UnwrapDelegateTarget(ref instance);
+            if (instance == null)
+                throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
+
+            var methodMocks = GetMethodMocksFromObject(instance);
+            if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
+                throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
+
+            var instanceMatcher = new ReferenceMatcher(instance);
+
+            foreach (var root in invocationTreeRoots.Values)
+                root.Children.RemoveAll(child => child.Matcher.Equals(instanceMatcher));
+
+            foreach (var root in arrangementTreeRoots.Values)
+                root.Children.RemoveAll(child => child.Matcher.Equals(instanceMatcher));
+        }
+
         internal void Assert(string message, object mock, Expression expr = null, Args args = null, Occurs occurs = null)
         {
             using (MockingContext.BeginFailureAggregation(message))

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -75,6 +75,7 @@ namespace Telerik.JustMock.Core
         private readonly List<WeakReference> controlledMocks = new List<WeakReference>();
 
         private bool isRetired;
+        internal bool DeferInOrderViolations { get; set; }
 
         internal static readonly HashSet<Type> KnownUnmockableTypes = new HashSet<Type>
             {
@@ -876,8 +877,17 @@ namespace Telerik.JustMock.Core
                 }
 
                 foreach (var behavior in methodMock.Behaviors.OfType<IAssertableBehavior>())
+                {
+                    if (ignoreMethodMockOccurrences && behavior is InOrderBehavior)
+                    {
+                        continue;
+                    }
+
                     if (!occurrenceAsserted || behavior != methodMock.OccurencesBehavior)
+                    {
                         behavior.Assert();
+                    }
+                }
             }
         }
 
@@ -912,10 +922,17 @@ namespace Telerik.JustMock.Core
             if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
                 throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
 
+            this.DeferInOrderViolations = true;
+
             foreach (var node in methodMocks)
             {
                 node.MethodMock.OccurencesBehavior.Reset();
                 node.MethodMock.IsUsed = false;
+
+                foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                {
+                    inOrderBehavior.Reset();
+                }
             }
 
             var instanceMatcher = new ReferenceMatcher(instance);
@@ -935,6 +952,19 @@ namespace Telerik.JustMock.Core
             var methodMocks = GetMethodMocksFromObject(instance);
             if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
                 throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
+
+            this.DeferInOrderViolations = true;
+
+            foreach (var node in methodMocks)
+            {
+                node.MethodMock.OccurencesBehavior.Reset();
+                node.MethodMock.IsUsed = false;
+
+                foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                {
+                    inOrderBehavior.Reset();
+                }
+            }
 
             var instanceMatcher = new ReferenceMatcher(instance);
 

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -922,18 +922,19 @@ namespace Telerik.JustMock.Core
             if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
                 throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
 
-            this.DeferInOrderViolations = true;
-
-            foreach (var node in methodMocks)
+            ExecuteWithDeferredInOrderViolations(() =>
             {
-                node.MethodMock.OccurencesBehavior.Reset();
-                node.MethodMock.IsUsed = false;
-
-                foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                foreach (var node in methodMocks)
                 {
-                    inOrderBehavior.Reset();
+                    node.MethodMock.OccurencesBehavior.Reset();
+                    node.MethodMock.IsUsed = false;
+
+                    foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                    {
+                        inOrderBehavior.Reset();
+                    }
                 }
-            }
+            });
 
             var instanceMatcher = new ReferenceMatcher(instance);
             foreach (var root in invocationTreeRoots.Values)
@@ -953,18 +954,19 @@ namespace Telerik.JustMock.Core
             if (methodMocks.Count == 0 && GetMockMixin(instance, null) == null)
                 throw new ArgumentException("Object is not a JustMock mock instance.", "instance");
 
-            this.DeferInOrderViolations = true;
-
-            foreach (var node in methodMocks)
+            ExecuteWithDeferredInOrderViolations(() =>
             {
-                node.MethodMock.OccurencesBehavior.Reset();
-                node.MethodMock.IsUsed = false;
-
-                foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                foreach (var node in methodMocks)
                 {
-                    inOrderBehavior.Reset();
+                    node.MethodMock.OccurencesBehavior.Reset();
+                    node.MethodMock.IsUsed = false;
+
+                    foreach (var inOrderBehavior in node.MethodMock.Behaviors.OfType<InOrderBehavior>())
+                    {
+                        inOrderBehavior.Reset();
+                    }
                 }
-            }
+            });
 
             var instanceMatcher = new ReferenceMatcher(instance);
 
@@ -973,6 +975,21 @@ namespace Telerik.JustMock.Core
 
             foreach (var root in arrangementTreeRoots.Values)
                 root.Children.RemoveAll(child => child.Matcher.Equals(instanceMatcher));
+        }
+
+        private void ExecuteWithDeferredInOrderViolations(Action action)
+        {
+            var previousValue = this.DeferInOrderViolations;
+            this.DeferInOrderViolations = true;
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                this.DeferInOrderViolations = previousValue;
+            }
         }
 
         internal void Assert(string message, object mock, Expression expr = null, Args args = null, Occurs occurs = null)

--- a/Telerik.JustMock/Mock.cs
+++ b/Telerik.JustMock/Mock.cs
@@ -125,6 +125,31 @@ namespace Telerik.JustMock
             ProfilerInterceptor.GuardInternal(() => MockingContext.RetireRepository());
         }
 
+        /// <summary>
+        /// Removes all arrangements and clears all recorded invocations for the specified mock instance.
+        /// The mock object itself remains usable; new arrangements may be added after this call.
+        /// </summary>
+        /// <param name="instance">The mock object to reset.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="instance"/> is not a mock object created by JustMock.</exception>
+        public static void Reset(object instance)
+        {
+            ProfilerInterceptor.GuardInternal(() => MockingContext.CurrentRepository.ResetInstance(instance));
+        }
+
+        /// <summary>
+        /// Clears the recorded invocations for all arrangements on the specified mock instance,
+        /// without removing or modifying the arrangements themselves.
+        /// Subsequent calls to <see cref="Mock.Assert"/> will count only invocations that occur after this call.
+        /// </summary>
+        /// <param name="instance">The mock object whose invocation history should be cleared.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="instance"/> is not a mock object created by JustMock.</exception>
+        public static void ClearInvocations(object instance)
+        {
+            ProfilerInterceptor.GuardInternal(() => MockingContext.CurrentRepository.ClearInvocations(instance));
+        }
+
 #if !LITE_EDITION
         /// <summary>
         /// Explicitly enables the interception of the given type by the profiler. Interception is usually enabled


### PR DESCRIPTION
#
This pull request introduces new functionality to allow clearing invocation history and resetting arrangements on mock objects, along with comprehensive tests for these features. The main changes include the implementation of `Mock.ClearInvocations` and `Mock.Reset` methods, updates to the internal repository to support these operations, and a new test fixture to verify their behavior.

### New Mock Control Features

* Added `Mock.ClearInvocations(object instance)` to clear invocation history for a mock without removing its arrangements. This lets you reset the call counters so that only subsequent invocations are counted in assertions. 
* Added `Mock.Reset(object instance)` to remove all arrangements and clear invocations for a mock, while keeping the mock usable for new arrangements.

### Internal Infrastructure

* Implemented `ClearInvocations` and `ResetInstance` methods in `MocksRepository`, handling validation, counter resets, and arrangement removal for mock objects.
* Added a `Reset` method to `InvocationOccurrenceBehavior` to reset the call count for arrangements.

### Testing

* Introduced a new test fixture `MockClearInvocationsFixture.cs` that thoroughly tests the behavior of clearing invocations and resetting mocks, including edge cases and error handling.

These changes improve the flexibility and testability of mock objects, allowing for more precise control over invocation tracking and arrangement management.

closes [#JM-201](https://progresssoftware.atlassian.net/jira/software/c/projects/JM/boards/10340?selectedIssue=JM-201)