### PR TITLE
Add licensing debug message and validation failure handling

### DIFF
--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -180,14 +180,9 @@ namespace Telerik.JustMock.Core
 #if FEATURE_LICENSING
         internal static string GetLicenseValidationFailureMessage()
         {
-            if (!LicenseManager.IsLicenseKeyFileFound)
+            if (!LicenseManager.IsLicenseKeyFileFound || !LicenseManager.IsLicenseKeyFileValid)
             {
-                return "No license key file is available.";
-            }
-
-            if (!LicenseManager.IsLicenseKeyFileValid)
-            {
-                return "A license key file is available, but it is invalid.";
+                return GetLicenseAvailabilityMessage(LicenseManager.IsLicenseKeyFileFound, LicenseManager.IsLicenseKeyFileValid);
             }
 
             return String.IsNullOrWhiteSpace(LicenseManager.Message) ? "License is not valid." : LicenseManager.Message;

--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -134,12 +134,75 @@ namespace Telerik.JustMock.Core
 
         internal int RepositoryId { get { return this.repositoryId; } }
 
+#if FEATURE_LICENSING
+        internal static string BuildLicensingDebugMessage()
+        {
+            var licensingMessage = String.IsNullOrWhiteSpace(LicenseManager.Message) ? "N/A" : LicenseManager.Message;
+            var productName = String.IsNullOrWhiteSpace(LicenseManager.LicenseProductName) ? "N/A" : LicenseManager.LicenseProductName;
+            var productVersion = String.IsNullOrWhiteSpace(LicenseManager.LicenseProductVersion) ? "N/A" : LicenseManager.LicenseProductVersion;
+            var licenseType = String.IsNullOrWhiteSpace(LicenseManager.LicenseType) ? "N/A" : LicenseManager.LicenseType;
+            var expiration = LicenseManager.LicenseExpiration.HasValue ? LicenseManager.LicenseExpiration.Value.ToString("O") : "N/A";
+            var licenseDate = LicenseManager.LicenseDate.ToString("O");
+            var availabilityMessage = GetLicenseAvailabilityMessage(LicenseManager.IsLicenseKeyFileFound, LicenseManager.IsLicenseKeyFileValid);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Licensing information:");
+            sb.AppendLine(String.Format("    IsLicenseValid: {0}", LicenseManager.IsLicenseValid));
+            sb.AppendLine(String.Format("    IsLicenseKeyFileFound: {0}", LicenseManager.IsLicenseKeyFileFound));
+            sb.AppendLine(String.Format("    IsLicenseKeyFileValid: {0}", LicenseManager.IsLicenseKeyFileValid));
+            sb.AppendLine(String.Format("    Availability: {0}", availabilityMessage));
+            sb.AppendLine(String.Format("    LicenseProductName: {0}", productName));
+            sb.AppendLine(String.Format("    LicenseProductCode: {0}", LicenseManager.LicenseProductCode));
+            sb.AppendLine(String.Format("    LicenseProductVersion: {0}", productVersion));
+            sb.AppendLine(String.Format("    LicenseType: {0}", licenseType));
+            sb.AppendLine(String.Format("    LicenseDate: {0}", licenseDate));
+            sb.AppendLine(String.Format("    LicenseExpiration: {0}", expiration));
+            sb.AppendLine(String.Format("    Message: {0}", licensingMessage));
+            return sb.ToString().TrimEnd();
+        }
+#endif
+
+        internal static string GetLicenseAvailabilityMessage(bool isLicenseKeyFileFound, bool isLicenseKeyFileValid)
+        {
+            if (!isLicenseKeyFileFound)
+            {
+                return "No license key file is available.";
+            }
+
+            if (!isLicenseKeyFileValid)
+            {
+                return "A license key file is available, but it is invalid.";
+            }
+
+            return "A license key file is available.";
+        }
+
+#if FEATURE_LICENSING
+        internal static string GetLicenseValidationFailureMessage()
+        {
+            if (!LicenseManager.IsLicenseKeyFileFound)
+            {
+                return "No license key file is available.";
+            }
+
+            if (!LicenseManager.IsLicenseKeyFileValid)
+            {
+                return "A license key file is available, but it is invalid.";
+            }
+
+            return String.IsNullOrWhiteSpace(LicenseManager.Message) ? "License is not valid." : LicenseManager.Message;
+        }
+#endif
+
         static MocksRepository()
         {
 #if FEATURE_LICENSING
+            DebugView.TraceEvent(IndentLevel.Configuration, BuildLicensingDebugMessage);
             if (!Licensing.LicenseManager.IsLicenseValid)
             {
-                throw new Licensing.LicenseException(Licensing.LicenseManager.Message);
+                var failureMessage = GetLicenseValidationFailureMessage();
+                DebugView.TraceEvent(IndentLevel.Warning, () => failureMessage);
+                throw new Licensing.LicenseException(failureMessage);
             }
 #endif
 


### PR DESCRIPTION
This pull request introduces improved diagnostics and error handling for licensing in the `MocksRepository` class. The main focus is on providing more detailed debug messages about the license state and ensuring that any license validation failures throw exceptions with more informative messages.

**Licensing diagnostics and error handling:**

* Added the `BuildLicensingDebugMessage` method (under `#if FEATURE_LICENSING`) to generate a comprehensive debug message with all relevant license properties for improved troubleshooting.
* Introduced the `GetLicenseAvailabilityMessage` method to provide a clear, human-readable status about the presence and validity of the license key file.
* Added the `GetLicenseValidationFailureMessage` method (under `#if FEATURE_LICENSING`) to centralize and improve the clarity of error messages when license validation fails.
* Updated the static constructor to log the licensing debug message and to throw a `LicenseException` with the improved failure message, also logging a warning if the license is invalid.

closes: JM-319