### PR TITLE
Revert throw message in LicenseException to use LicenseManager.Message

### DIFF
--- a/Telerik.JustMock/Core/MocksRepository.cs
+++ b/Telerik.JustMock/Core/MocksRepository.cs
@@ -198,7 +198,7 @@ namespace Telerik.JustMock.Core
             {
                 var failureMessage = GetLicenseValidationFailureMessage();
                 DebugView.TraceEvent(IndentLevel.Warning, () => failureMessage);
-                throw new Licensing.LicenseException(failureMessage);
+                throw new Licensing.LicenseException(Licensing.LicenseManager.Message);
             }
 #endif
 


### PR DESCRIPTION
part of JM-344